### PR TITLE
fix(fetch_config): Make sure arguments is an array

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -77,9 +77,10 @@ export class Config {
     }
 
     let result = this.namespaces;
+    let args = Array.from(arguments);
 
-    for (let index in arguments) {
-      let key   = arguments[index];
+    for (let index in args) {
+      let key   = args[index];
       let value = result[key];
       if (!value) {
         return value;


### PR DESCRIPTION
Arguments is not an array, which caused unexpected behaviour in Safari.
