### PR TITLE
fix(doc-readme): minor typo

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@
 
 > Aurelia-view-manager is a plugin that allows you to configure views by key
 > using variables. This allows you to offer support for more than one framework
-> (boorstrap, foundation etc). It also allows the user to provide a custom view
+> (bootstrap, foundation etc). It also allows the user to provide a custom view
 > without forking or overriding.
 
 When you're introduced to aurelia the first time, you quickly learn that


### PR DESCRIPTION
### Summary

- fixed tiny typo in "bootstrap" in [doc/README.md](../tree/master/doc/README.md#what-is-aurelia-view-manager)